### PR TITLE
Update simplesearch_searchbox.html.twig

### DIFF
--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -33,4 +33,4 @@
 		return false;
 	});
 });
-</script>' , {'group': 'bottom'}) %}
+' , {'group': 'bottom'}) %}


### PR DESCRIPTION
Removed redundant </script> from line 36. When you call on JS assets, it automatically adds your style tags, both opening and closing
