### PR TITLE
Update simplesearch_searchbox.html.twig

### DIFF
--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -1,6 +1,6 @@
 <div class="search-full">
-    <div class="search-container">
-        <form role="search" method="get" class="search-form" action="{{ base_url }}{{ config.plugins.simplesearch.route}}/query">
+    <div role="search" class="search-container">
+        <form method="get" class="search-form" action="{{ base_url }}{{ config.plugins.simplesearch.route}}/query">
 			<label>
 				<span class="screen-reader-text">{{ 'THEME_NUCLEARE.SEARCH.FOR'|t }} :</span>
 				<input type="search" class="search-field" placeholder="{{ 'THEME_NUCLEARE.SEARCH.PLACEHOLDER'|t }}" name="search-field">


### PR DESCRIPTION
w3 validation does not like role="search" in a form tag for some reason, so putting the role attribute in the container fixes the validation error and still serves its purpose.
