### PR TITLE
Update base.html.twig

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -77,7 +77,7 @@
                 {% if theme_config.header_image.enabled %}
                     <figure class="entry-featured-image">
                     <a class="site-header-image" href="{{ base_url == '' ? '/' : base_url }}" rel="home" {{ theme_config.header_image.height ? 'style="max-height: ' ~ theme_config.header_image.height ~ '"' : '' }}>
-                        <img src="{{ theme_url }}/{{ theme_config.header_image.src }}" width="{{ theme_config.header_image.width ? : '100%' }}" height="auto"  alt="" class="custom-header">
+                        <img src="{{ theme_url }}/{{ theme_config.header_image.src }}" alt="Featured Image" class="custom-header">
                         <figcaption>
                         <p>
                             <i class="fa fa-home"></i>


### PR DESCRIPTION
More w3 validation fixes.
- Bad value 100% for attribute width on element img: Expected a digit but saw % instead.
- Bad value auto for attribute height on element img: Expected a digit but saw a instead.
- The width attribute is already in the CSS styling and the height attribute does nothing as its read incorrectly anyway
- Added alt description to featured image, search engines do not like empty alt tags
