### PR TITLE
Update style.css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1352,11 +1352,9 @@ label[for="show-more-tags"]:hover {
 	display: block;
 	max-height: 500px;
 	overflow: hidden;
-	background-color: rgba(0, 0, 0, 0.6);
 }
 .site-header-image img {
 	position: relative;
-	z-index: -1;
 }
 .site-branding .entry-featured-image:hover img {
 	z-index: 0;


### PR DESCRIPTION
As a photographer, I would want my entry featured image to appear as it was meant to be displayed, not dark and washed out. Removing the dark background on the featured image looks nicer, and honestly makes more sense. The hover still functions, and I removed the annoying solid color flash by removing the z-index attribute.

With these changes, the featured image now acts just like the blog post images do. If you think people are going to want their header image to be dark, then I might suggest the option to disable the dark overlay. Either way, the z-index attribute was giving a strange solid color flash that ruined the smooth transition.
