### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/nucleare.yaml
+++ b/nucleare.yaml
@@ -8,10 +8,3 @@ header_image:
   enabled: true
   src: assets/header-code.jpg
   height: 400px
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/nucleare


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
